### PR TITLE
Changed php-get snippet :

### DIFF
--- a/php-getset.sublime-snippet
+++ b/php-getset.sublime-snippet
@@ -41,9 +41,10 @@ public function get${1/(.*)/\u$1/:[ Prop name ]}()
  * @param  [type] \$${1:[ Prop name ]} [description]
  * @return [class type]    \$this
  */
-public function set${1/(.*)/\u$1/:[ Prop name ]}(\$new${1/(.*)/\u$1/:[ Prop name ]})
+public function set${1/(.*)/\u$1/:[ Prop name ]}(\$${1/(.*)/$1/:[ Prop name ]})
 {
-    \$this->${1:[Prop name ]} = \$new${1/(.*)/\u$1/:[ Prop name ]};
+    \$this->${1:[Prop name ]} = \$${1/(.*)/$1/:[ Prop name ]};
+
     return \$this;
 }
 ]]></content>


### PR DESCRIPTION
- Added a blank line before return in set\* (according to PSR1)
- Removed the `new*` in set

almost every projet / lib / framework do not use  `new*` as argument. IMHO, we should remove it to be more efficient.

Nice work BTW.
