### PR TITLE
Fixes for the getset snippet.

### DIFF
--- a/php-getset.sublime-snippet
+++ b/php-getset.sublime-snippet
@@ -39,8 +39,7 @@ public function get${1/(.*)/\u$1/:[ Prop name ]}() {
  *
  * @param ${3/(.*)/\u$1/:[type]} \$new${1:[ Prop name ]} ${4/(.*)/\u$1/:[description]}
  */
-public function set${1/(.*)/\u$1/:[ Prop name ]}(\$${1/(.*)/$1/:[ Prop name ]})
-{
+public function set${1/(.*)/\u$1/:[ Prop name ]}(\$${1/(.*)/$1/:[ Prop name ]}) {
     \$this->${1:[Prop name ]} = \$${1/(.*)/$1/:[ Prop name ]};
 
     return \$this;

--- a/php-getset.sublime-snippet
+++ b/php-getset.sublime-snippet
@@ -30,8 +30,7 @@
  *
  * @return ${3:[type]} ${4:[description]}
  */
-public function get${1/(.*)/\u$1/:[ Prop name ]}()
-{
+public function get${1/(.*)/\u$1/:[ Prop name ]}() {
     return \$this->${1:[ Prop name ]};
 }
 
@@ -40,8 +39,7 @@ public function get${1/(.*)/\u$1/:[ Prop name ]}()
  *
  * @param ${3/(.*)/\u$1/:[type]} \$new${1:[ Prop name ]} ${4/(.*)/\u$1/:[description]}
  */
-public function set${1/(.*)/\u$1/:[ Prop name ]}(\$new${1/(.*)/\u$1/:[ Prop name ]})
-{
+public function set${1/(.*)/\u$1/:[ Prop name ]}(\$new${1/(.*)/\u$1/:[ Prop name ]}) {
     \$this->${1:[Prop name ]} = \$new${1/(.*)/\u$1/:[ Prop name ]};
 }
 ]]></content>

--- a/php-getset.sublime-snippet
+++ b/php-getset.sublime-snippet
@@ -26,9 +26,9 @@
     <content><![CDATA[
 
 /**
- * [get${1/(.*)/\u$1/:[ Prop name ]}() description here]
+ * ${2:[description here]}
  *
- * @return [type] [description]
+ * @return ${3:[type]} ${4:[description]}
  */
 public function get${1/(.*)/\u$1/:[ Prop name ]}()
 {
@@ -36,15 +36,13 @@ public function get${1/(.*)/\u$1/:[ Prop name ]}()
 }
 
 /**
- * [set${1/(.*)/\u$1/:[ Prop name ]}() description here]
+ * ${5:[Description]}
  *
- * @param  [type] \$${1:[ Prop name ]} [description]
- * @return [class type]    \$this
+ * @param ${3/(.*)/\u$1/:[type]} \$new${1:[ Prop name ]} ${4/(.*)/\u$1/:[description]}
  */
 public function set${1/(.*)/\u$1/:[ Prop name ]}(\$new${1/(.*)/\u$1/:[ Prop name ]})
 {
     \$this->${1:[Prop name ]} = \$new${1/(.*)/\u$1/:[ Prop name ]};
-    return \$this;
 }
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->


### PR DESCRIPTION
I've made some changes to the getset snippet so that all the fields in []'s receive focus when the user tabs between them, in my version of Sublime (2.0.1, Build 2217) only the 1st description & the variable name received focus ...

I've also changed the method structure so it complies with PSR-01

Just a quick question about the setter, why does it return the whole object?
