### PR TITLE
 Changed getset template to match private and protected properties (beginning with underscore)

### DIFF
--- a/php-getset.sublime-snippet
+++ b/php-getset.sublime-snippet
@@ -30,17 +30,17 @@
  *
  * @return ${3:[type]} ${4:[description]}
  */
-public function get${1/(.*)/\u$1/:[ Prop name ]}() {
+public function get${1/_?(.*)/\u$1/:[ Prop name ]}() {
     return \$this->${1:[ Prop name ]};
 }
 
 /**
  * ${5:[Description]}
  *
- * @param ${3/(.*)/\u$1/:[type]} \$new${1:[ Prop name ]} ${4/(.*)/\u$1/:[description]}
+ * @param ${3/(.*)/\u$1/:[type]} \$new${1/_?(.*)/$1/:[ Prop name ]} ${4/(.*)/\u$1/:[description]}
  */
-public function set${1/(.*)/\u$1/:[ Prop name ]}(\$${1/(.*)/$1/:[ Prop name ]}) {
-    \$this->${1:[Prop name ]} = \$${1/(.*)/$1/:[ Prop name ]};
+public function set${1/_?(.*)/\u$1/:[ Prop name ]}(\$${1/_?(.*)/$1/:[ Prop name ]}) {
+    \$this->${1:[Prop name ]} = \$${1/_?(.*)/$1/:[ Prop name ]};
 
     return \$this;
 }


### PR DESCRIPTION
Actually, if you have a property named $_db, the php-getset method will output the two following methods:

public function get_db(){}
public function set_db($_db){}

With my modification, you will have:

public function getDb(){}
public function setDb($db){}

Best Regards,

Vincent
