### PR TITLE
Standard PHP License for private code

### DIFF
--- a/php-license.sublime-snippet
+++ b/php-license.sublime-snippet
@@ -1,0 +1,56 @@
+<!--
+    php-license
+        Inserts a DocBlock for a standard license.
+
+    HOW TO USE
+        In your PHP class, go to the top of the file, and type
+
+            php-license<TAB>
+
+        Sublime Text will add the docblock for you. Now use <TAB> to work
+        through the fields you need to complete.
+
+-->
+<snippet>
+    <content><![CDATA[
+/**
+ * MIT License
+ * ===========
+ *
+ * Copyright (c) 2013 ${1:[Your name]} <${2:[Your email]}>
+ *
+ * Code contained within this file is copyright to the respective copyright
+ * holder, listed below this notice. This code may not be redistributed, 
+ * resold or released publicly without the prior written concent of its 
+ * copyright holders. Usage of this code is strictly under license from the
+ * copyright holder, and it may not be used outside of the package listed 
+ * below.
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @category   ${3:[ Category ]}
+ * @package    ${4:[ Package ]}
+ * @subpackage ${5:[ Subpackage ]}
+ * @author     ${1:[ Your name ]} <${2:[ [Your email ]}>
+ * @copyright  2012 ${1:[ Your name ]}.
+ * @license    http://www.opensource.org/licenses/mit-license.php  MIT License
+ * @version    ${6:[ Version ]}
+ * @link       http://${7:[ Your website ]}
+ */
+]]></content>
+    <!-- Optional: Tab trigger to activate the snippet -->
+    <tabTrigger>php-license</tabTrigger>
+    <!-- Optional: Scope the tab trigger will be active in -->
+    <scope>source.php</scope>
+    <!-- Optional: Description to show in the menu -->
+    <description>Insert a standard copright license DocBlock</description>
+</snippet>


### PR DESCRIPTION
A standard copyright license for private code, based on the MIT template, but modified to reflect that the code is not public and is for internal use only under license of the copyright holder.
